### PR TITLE
Simple logging with span

### DIFF
--- a/phat/.gitignore
+++ b/phat/.gitignore
@@ -12,3 +12,4 @@
 
 node_modules
 
+target/

--- a/phat/contracts/action_offchain_rollup/Cargo.lock
+++ b/phat/contracts/action_offchain_rollup/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "hex-literal",
  "hex_fmt",
  "ink",
+ "logging",
  "parity-scale-codec",
  "phat_js",
  "phat_offchain_rollup",
@@ -221,7 +222,9 @@ dependencies = [
 name = "brick_profile"
 version = "0.2.0"
 dependencies = [
+ "hex_fmt",
  "ink",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "pink-json 0.4.0 (git+https://github.com/Phala-Network/pink-json.git?branch=pink)",
@@ -1403,6 +1406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "parity-scale-codec",
+ "pink-extension",
+ "pink-extension-macro",
+ "scale-info",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1637,7 @@ name = "phat_js"
 version = "0.1.0"
 dependencies = [
  "ink",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "scale-info",
@@ -1635,6 +1650,7 @@ dependencies = [
  "ethabi",
  "hex",
  "ink",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "pink-json 0.4.0 (git+https://github.com/Phala-Network/pink-json.git?branch=pink)",
@@ -2211,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
+checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2226,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
+checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/phat/contracts/action_offchain_rollup/Cargo.toml
+++ b/phat/contracts/action_offchain_rollup/Cargo.toml
@@ -33,6 +33,7 @@ brick_profile = { path = "../../contracts/brick_profile", default-features = fal
 
 hex = { version = "0.4", default-features = false }
 hex_fmt = { version = "0.3", default-features = false }
+logging = { path = "../../crates/logging", default-features = false }
 
 [dev-dependencies]
 dotenvy = "0.15"
@@ -58,6 +59,7 @@ std = [
     "pink-json/std",
     "pink-web3/std",
     "ethabi/std",
+    "logging/std",
 ]
 ink-as-dependency = [ "brick_profile/ink-as-dependency" ]
 

--- a/phat/contracts/brick_profile/Cargo.lock
+++ b/phat/contracts/brick_profile/Cargo.lock
@@ -203,7 +203,9 @@ dependencies = [
  "dotenvy",
  "env_logger 0.9.3",
  "hex",
+ "hex_fmt",
  "ink",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "pink-extension-runtime",
@@ -1372,6 +1374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "parity-scale-codec",
+ "pink-extension",
+ "pink-extension-macro",
+ "scale-info",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
+checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2141,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
+checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/phat/contracts/brick_profile/Cargo.toml
+++ b/phat/contracts/brick_profile/Cargo.toml
@@ -16,6 +16,8 @@ secp256k1 = { version = "0.24.3", default-features = false }
 pink-extension = { version = "0.4", default-features = false }
 pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false, features = ["de-number-as-str"] }
 pink-web3 = { version = "0.20", default-features = false, features = ["pink", "signing"] }
+logging = { path = "../../crates/logging", default-features = false }
+hex_fmt = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 dotenvy = "0.15"
@@ -37,6 +39,7 @@ std = [
     "pink-extension/std",
     "pink-json/std",
     "pink-web3/std",
+    "logging/std",
 ]
 ink-as-dependency = []
 

--- a/phat/contracts/brick_profile/lib.rs
+++ b/phat/contracts/brick_profile/lib.rs
@@ -8,9 +8,10 @@ pub use brick_profile::*;
 mod brick_profile {
     use alloc::{format, string::String, vec::Vec};
     use core::convert::TryInto;
-    use ink::storage::Mapping;
     #[cfg(feature = "std")]
     use ink::storage::traits::StorageLayout;
+    use ink::storage::Mapping;
+    use logging::info;
     use pink_extension as pink;
     use pink_extension::chain_extension::signing;
     use pink_json as json;
@@ -260,7 +261,6 @@ mod brick_profile {
             rpc: String,
             sk: Vec<u8>,
         ) -> Result<ExternalAccountId> {
-
             // Deprecated in first release
             return Err(Error::Deprecated);
 
@@ -334,14 +334,17 @@ mod brick_profile {
 
         /// Called by a scheduler periodically with Query
         #[ink(message)]
-        pub fn poll(&mut self, workflow_id: WorkflowId) -> Result<bool> {
+        pub fn poll(&mut self, workflow_id: WorkflowId, poll_id: String) -> Result<bool> {
             use ink::env::call::{build_call, ExecutionInput, Selector};
-
             // Trick here: We only allow Query the `poll()` function, so the following `workflow_session` change only
             // lives in this call and is never written back to chain.
             if pink::ext().is_in_transaction() {
                 return Err(Error::NoPollForTransaction);
             }
+
+            let _span = logging::enter_span(&format!("poll_id={poll_id}"));
+            let profile = hex_fmt::HexFmt(self.env().account_id());
+            info!("polling profile 0x{profile}:{workflow_id}");
 
             let now_workflow = self.ensure_enabled_workflow(workflow_id)?;
             // call `this.set_workflow_session()` in a cross-contract manner to let the `self.workflow_session` value
@@ -391,14 +394,14 @@ mod brick_profile {
         #[ink(message)]
         pub fn sign_evm_transaction(&self, tx: Vec<u8>) -> Result<Vec<u8>> {
             let now_workflow_id = self.ensure_workflow_session()?;
-            pink::info!("Workflow {} asks for EVM tx signing", now_workflow_id);
+            info!("Workflow {} asks for EVM tx signing", now_workflow_id);
 
             let account_id = self
                 .authorized_account
                 .get(now_workflow_id)
                 .ok_or(Error::NoAuthorizedExternalAccount)?;
             let account = self.ensure_enabled_external_account(account_id)?;
-            pink::info!("ExternalAccount {} is allowed", account_id);
+            info!("ExternalAccount {} is allowed", account_id);
 
             let phttp = PinkHttp::new(account.rpc.clone());
             let web3 = pink_web3::Web3::new(phttp);
@@ -487,6 +490,7 @@ mod brick_profile {
     mod tests {
         use super::*;
         use alloc::collections::BTreeMap;
+        use logging::warn;
 
         struct EnvVars {
             rpc: String,
@@ -599,7 +603,7 @@ mod brick_profile {
             ));
             profile.dump_evm_account(ea2_id).unwrap();
             let sk = profile.get_dumped_key(ea2_id).unwrap();
-            pink::warn!("Dumped sk: 0x{}", hex::encode(sk));
+            warn!("Dumped sk: 0x{}", hex::encode(sk));
 
             // Access control
             let accounts = ink::env::test::default_accounts::<pink::PinkEnvironment>();

--- a/phat/contracts/brick_profile_factory/Cargo.lock
+++ b/phat/contracts/brick_profile_factory/Cargo.lock
@@ -78,7 +78,9 @@ dependencies = [
 name = "brick_profile"
 version = "0.2.0"
 dependencies = [
+ "hex_fmt",
  "ink",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "pink-json 0.4.0 (git+https://github.com/Phala-Network/pink-json.git?branch=pink)",
@@ -440,6 +442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +764,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "parity-scale-codec",
+ "pink-extension",
+ "pink-extension-macro",
+ "scale-info",
 ]
 
 [[package]]
@@ -1137,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
+checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -1151,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
+checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/phat/contracts/lego_rs/Cargo.lock
+++ b/phat/contracts/lego_rs/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "hex",
  "ink",
  "ink_e2e",
+ "logging",
  "parity-scale-codec",
  "pink-extension",
  "pink-json",
@@ -2496,6 +2497,17 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "parity-scale-codec",
+ "pink-extension",
+ "pink-extension-macro",
+ "scale-info",
+]
 
 [[package]]
 name = "lru"

--- a/phat/contracts/lego_rs/lib.rs
+++ b/phat/contracts/lego_rs/lib.rs
@@ -9,7 +9,7 @@ mod lego {
     use alloc::string::String;
     use alloc::vec::Vec;
     use ink::env::Error;
-    use pink::{info, warn};
+    use logging::{info, warn};
     use scale::Encode;
     use serde::Deserialize;
     use this_crate::{version_tuple, VersionTuple};
@@ -78,7 +78,7 @@ mod lego {
                     result = format!("{res:?}");
                 }
                 Action::Log => {
-                    pink::info!("output={}", result);
+                    info!("output={}", result);
                     result.clear();
                 }
             }

--- a/phat/contracts/tagbag/.gitignore
+++ b/phat/contracts/tagbag/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/phat/contracts/tagbag/Cargo.toml
+++ b/phat/contracts/tagbag/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lego_rs"
+name = "tagbag"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"
@@ -10,11 +10,7 @@ pink = { package = "pink-extension", version = "0.4", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
-serde = { version = "=1.0.185", default-features = false, features = ["derive"] }
-pink-json = { version = "0.4.0", default-features = false }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
 logging = { path = "../../crates/logging", default-features = false }
-this-crate = "0.1"
 
 [dev-dependencies]
 ink_e2e = "4.2.0"
@@ -26,15 +22,9 @@ path = "lib.rs"
 default = ["std"]
 std = [
     "ink/std",
-    "pink/std",
     "scale/std",
     "scale-info/std",
-    "pink-json/std",
-    "serde/std",
     "logging/std",
 ]
 ink-as-dependency = []
 e2e-tests = []
-
-[patch.crates-io]
-serde = { git = "https://github.com/kvinwang/serde.git", branch = "patched-v1.0.185" }

--- a/phat/contracts/tagbag/lib.rs
+++ b/phat/contracts/tagbag/lib.rs
@@ -1,0 +1,48 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+
+#[ink::contract]
+mod tagbag {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct TagBag {
+        tags: Vec<String>,
+    }
+
+    impl TagBag {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self::default()
+        }
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Default::default()
+        }
+    }
+
+    impl logging::TagStack for TagBag {
+        #[ink(message)]
+        fn push_tag(&mut self, tag: String) {
+            if pink::ext().is_in_transaction() {
+                return;
+            }
+            self.tags.push(tag);
+        }
+
+        #[ink(message)]
+        fn pop_tag(&mut self) {
+            if pink::ext().is_in_transaction() {
+                return;
+            }
+            _ = self.tags.pop();
+        }
+
+        #[ink(message)]
+        fn tags(&self) -> Vec<String> {
+            self.tags.clone()
+        }
+    }
+}

--- a/phat/crates/js/Cargo.toml
+++ b/phat/crates/js/Cargo.toml
@@ -14,6 +14,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 pink-extension = { version = "0.4", default-features = false }
+logging = { path = "../../crates/logging", default-features = false }
 
 [features]
 default = ["std"]
@@ -21,4 +22,5 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
+    "logging/std",
 ]

--- a/phat/crates/js/lib.rs
+++ b/phat/crates/js/lib.rs
@@ -6,6 +6,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use pink_extension as pink;
 use scale::{Decode, Encode};
+use logging::info;
 
 #[derive(Debug, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
@@ -31,7 +32,7 @@ pub fn eval(script: &str, args: &[String]) -> Result<Output, String> {
         .returns::<Result<Result<Output, String>, ink::LangError>>()
         .invoke()
         .expect("Failed to invoke delegate call");
-    pink::info!("eval result: {result:?}");
+    info!("eval result: {result:?}");
     result
 }
 

--- a/phat/crates/logging/Cargo.lock
+++ b/phat/crates/logging/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -25,9 +25,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -37,9 +37,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -79,9 +79,12 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -91,9 +94,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -167,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
@@ -185,10 +188,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -229,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -241,9 +250,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -279,19 +288,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
 [[package]]
 name = "ink"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b374fcb3c9b91f8293bdc93d69292e2ec6ea19e97e00725806d79bf563fa5e55"
+checksum = "e9fd4f77d66c94aa7f27a7cf41cd2edbc2229afe34ec475c3f32b6e8fdf561a0"
 dependencies = [
  "derive_more",
  "ink_env",
@@ -305,18 +314,18 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdc9dbbc38d0e0cd7b053068112ca8ab8140b8ece33b9e197af5544ed3d97e1"
+checksum = "870914970470fd77a3f42d3c5d1918b562817af127fd063ee8b1d9fbf59aa1fe"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_codegen"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251e64f2dd74e98329a05812f067f34e2b494a7b1325e538165e481378a72747"
+checksum = "22d79057b2565df31a10af6510a44b161093f110c5f9c22ad02c20af9cea4c29"
 dependencies = [
  "blake2",
  "derive_more",
@@ -333,14 +342,14 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "ink_engine"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c4af49e092a93e65d1161ce31d23c2e57d724462c96a8944acd647a52787f0"
+checksum = "722ec3a5eb557124b001c60ff8f961079f6d566af643edea579f152b15822fe5"
 dependencies = [
  "blake2",
  "derive_more",
@@ -353,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5e1505c5deb7280743e4d7df72a91f52bbf4cb063f464c73f89dce00c70f92"
+checksum = "584e73bc0982f6f1a067bb63ebc75262f6dc54ed2a17060efa73eaba84dc9308"
 dependencies = [
  "arrayref",
  "blake2",
@@ -381,23 +390,23 @@ dependencies = [
 
 [[package]]
 name = "ink_ir"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0e2d96fc6e5b5cb1696b8057e72958315076dbe3f427e8f7722a346344f27a"
+checksum = "5b529c941518e8f450395fab9fe8ebba0a7acbb18778fc7e0a87f6248286ec72"
 dependencies = [
  "blake2",
  "either",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "ink_macro"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15abf802e89909c65b6c15d0c655beb3c7ab86309626effb5d9b330d97308114"
+checksum = "8579576c995ca9baa032584beca19155cbd63b6739570aa9da4d35a0415f4be8"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -405,15 +414,15 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "synstructure",
 ]
 
 [[package]]
 name = "ink_metadata"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af082b4c2eb246d27b358411ef950811f851c1099aa507ba4bcdd7214d40ccd"
+checksum = "3fddff95ce3e01f42002fdaf96edda691dbccb08c9ae76d7101daa1fa634e601"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -425,18 +434,18 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0662ba1d4aa26f0fea36ce6ef9ef1e510e24c900597d703b148c8c23b675b9"
+checksum = "d8cfdf91d2b442f08efb34dd3780fd6fbd3d033f63b42f62684fe47534948ef6"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52693c5e74600f5bd4c0f6d447ba9c4e491e4edf685eaf9f9f347a3cb1cde66b"
+checksum = "6414bcad12ebf0c3abbbb192a09e4d06e22f662cf3e19545204e1b0684be12a1"
 dependencies = [
  "derive_more",
  "ink_prelude",
@@ -449,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02d898d2ff85c88126d284854e1198771be94282d44a5d77fdc8a9bce43e398"
+checksum = "bd728409de235de0489f71ee2d1beb320613fdb50dda9fa1c564825f4ad06daa"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -467,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec58d70937c1e1490a00b84e2eb9a799f1a5331dd0e5cc68d550de1dbf6a8f4"
+checksum = "a8dcb50f70377ac35c28d63b06383a0a3cbb79542ea4cdc5b00e3e2b3de4a549"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
@@ -479,24 +488,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
@@ -512,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "keccak"
@@ -526,34 +523,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "lego"
-version = "0.1.0"
-dependencies = [
- "ink",
- "parity-scale-codec",
- "phat_js",
- "pink-extension",
- "scale-info",
- "this-crate",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logging"
@@ -568,17 +553,38 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -589,9 +595,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -603,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -615,29 +621,19 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
-name = "phat_js"
-version = "0.1.0"
-dependencies = [
- "ink",
- "logging",
- "parity-scale-codec",
- "pink-extension",
- "scale-info",
-]
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pink-extension"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e023330af21b2ff1c774bc606897470709a55508a1d3b3f6b805145d597b86a1"
+checksum = "74333ed749dd52e97b091654bf5f56f47f0aa8cf62d6324693991988142cc59c"
 dependencies = [
  "ink",
  "log",
+ "num_enum",
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
@@ -646,16 +642,16 @@ dependencies = [
 
 [[package]]
 name = "pink-extension-macro"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8dfee165489e2147ef76bb37507f3653a8156b55e2bc6f8992f2847a7556f6"
+checksum = "d38ff5c86454de8be6134fcf510009d3a84e9bfc758970755458ba7bafaf496b"
 dependencies = [
  "heck",
  "ink_ir",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "unzip3",
 ]
 
@@ -671,18 +667,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -695,9 +691,21 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -706,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rlibc"
@@ -718,13 +726,12 @@ checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -732,15 +739,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scale-bits"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
+checksum = "036575c29af9b6e4866ffb7fa055dbf623fe7a9cc159b33786de6013a6969d89"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -748,22 +755,23 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.5.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e5527e4b3bf079d4c0b2f253418598c380722ba37ef20fac9088081407f2b6"
+checksum = "7789f5728e4e954aaa20cadcc370b99096fb8645fca3c9333ace44bb18f30095"
 dependencies = [
+ "derive_more",
  "parity-scale-codec",
  "scale-bits",
  "scale-decode-derive",
  "scale-info",
- "thiserror",
+ "smallvec",
 ]
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.5.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38741b2f78e4391b94eac6b102af0f6ea2b0f7fe65adb55d7f4004f507854db"
+checksum = "27873eb6005868f8cc72dcfe109fae664cf51223d35387bc2f28be4c28d94c47"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -774,21 +782,22 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.1.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15546e5efbb45f0fc2291f7e202dee8623274c5d8bbfdf9c6886cc8b44a7ced3"
+checksum = "6d70cb4b29360105483fac1ed567ff95d65224a14dd275b6303ed0a654c78de5"
 dependencies = [
+ "derive_more",
  "parity-scale-codec",
  "scale-encode-derive",
  "scale-info",
- "thiserror",
+ "smallvec",
 ]
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.1.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd983cf0a9effd76138554ead18a6de542d1af175ac12fd5e91836c5c0268082"
+checksum = "995491f110efdc6bea96d6a746140e32bfceb4ea47510750a5467295a4707a25"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -843,29 +852,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -874,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -892,6 +901,12 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "static_assertions"
@@ -924,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -941,7 +956,7 @@ checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "unicode-xid",
 ]
 
@@ -967,36 +982,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c3dac231fac5770597ae4670029b06ea5adab46e2fd192838e9a77007ec656"
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1011,9 +1006,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-xid"
@@ -1075,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1090,51 +1085,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]

--- a/phat/crates/logging/Cargo.toml
+++ b/phat/crates/logging/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "logging"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.2", default-features = false }
+pink = { package = "pink-extension", version = "0.4", default-features = false }
+pink_macro = { package = "pink-extension-macro", version = "0.4", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false }
+scale-info = { version = "2.9", default-features = false }
+
+
+[features]
+default = ["std"]
+std = ["ink/std", "pink/std"]

--- a/phat/crates/logging/src/lib.rs
+++ b/phat/crates/logging/src/lib.rs
@@ -1,0 +1,116 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{
+    fmt::Arguments,
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use ink::primitives::AccountId;
+use pink_macro::driver;
+
+#[driver]
+#[ink::trait_definition]
+pub trait TagStack {
+    #[ink(message)]
+    fn push_tag(&mut self, tag: String);
+    #[ink(message)]
+    fn pop_tag(&mut self);
+    #[ink(message)]
+    fn tags(&self) -> Vec<String>;
+}
+
+#[derive(Default)]
+pub struct Span {
+    bag: Option<TagStackRef>,
+}
+
+impl Drop for Span {
+    fn drop(&mut self) {
+        if let Some(mut bag) = self.bag.take() {
+            bag.pop_tag();
+        }
+    }
+}
+
+/// Enter a log span. The span will be exited when the returned value is dropped.
+pub fn enter_span(span: &str) -> Span {
+    if pink::ext().is_in_transaction() {
+        return Span::default();
+    }
+    let Some(mut bag) = TagStackRef::instance() else {
+        return Span::default();
+    };
+    bag.push_tag(span.to_string());
+    Span { bag: Some(bag) }
+}
+
+pub fn tagged_prefix() -> Option<String> {
+    let bag = TagStackRef::instance()?;
+    Some(bag.tags().join(","))
+}
+
+pub fn log(level: u8, args: Arguments<'_>) {
+    let message = match tagged_prefix() {
+        Some(prefix) => {
+            format!("[{}]: {}", prefix, args)
+        }
+        None => {
+            format!("{}", args)
+        }
+    };
+    pink::ext().log(level, &message);
+}
+
+/// The `log!` macro allows you to log messages with specific logging levels in pink contract.
+///
+/// It is a flexible macro that uses a provided log level (trace, debug, info, warn, error),
+/// followed by a format string and an optional list of arguments to generate the final log message.
+#[macro_export]
+macro_rules! log {
+    ($level: expr, $($arg:tt)+) => {{ $crate::log($level, ::core::format_args!($($arg)+)) }}
+}
+
+/// Same as `info!` but at Error level.
+#[macro_export(local_inner_macros)]
+macro_rules! error {
+    ($($arg:tt)+) => {{ log!(1, $($arg)+) }}
+}
+
+/// Same as `info!` but at Warn level.
+#[macro_export(local_inner_macros)]
+macro_rules! warn {
+    ($($arg:tt)+) => {{ log!(2, $($arg)+) }}
+}
+
+/// Macro `info!` logs messages at the Info level in pink contract.
+///
+/// This macro is used to log information that would be helpful to understand the general flow
+/// of the system's execution. It is similar to `log::info`, but it is specifically designed
+/// to work within the pink contract environment.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```ignore
+/// logging::info!("This is an information message.");
+/// let answer = 42;
+/// logging::info!("The answer is {}.", answer);
+/// ```
+///
+/// The above example would log "This is an information message." and
+/// "The answer is 42." at the Info level.
+#[macro_export(local_inner_macros)]
+macro_rules! info {
+    ($($arg:tt)+) => {{ log!(3, $($arg)+) }}
+}
+
+/// Same as `info!` but at Debug level.
+#[macro_export(local_inner_macros)]
+macro_rules! debug {
+    ($($arg:tt)+) => {{ log!(4, $($arg)+) }}
+}

--- a/phat/crates/rollup/Cargo.toml
+++ b/phat/crates/rollup/Cargo.toml
@@ -28,6 +28,7 @@ ethabi = { version = "18.0.0", default-features = false, features = [
 
 # for Substrate rollup
 subrpc = { package = "pink-subrpc", version = "0.4.1", default-features = false, optional = true }
+logging = { path = "../../crates/logging", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
@@ -43,6 +44,7 @@ std = [
     "pink-web3/std",
     "ethabi/std",
     "subrpc/std",
+    "logging/std",
 ]
 logging = [
     "pink-extension",

--- a/phat/crates/rollup/src/clients/evm.rs
+++ b/phat/crates/rollup/src/clients/evm.rs
@@ -20,6 +20,8 @@ use pink_web3::{
     transports::{resolve_ready, PinkHttp},
     types::{BlockId, BlockNumber, Bytes, TransactionRequest, U64},
 };
+#[cfg(feature = "logging")]
+use logging::warn;
 
 const ANCHOR_ABI: &[u8] = include_bytes!("../../res/anchor.abi.json");
 const DEFAULT_QUEUE_PREFIX: &[u8] = b"q/";
@@ -66,7 +68,7 @@ impl KvSnapshot for EvmSnapshot {
         .or(Err(kv_session::Error::FailedToGetStorage))?;
 
         #[cfg(feature = "logging")]
-        pink::warn!(
+        warn!(
             "Storage[{}] = {:?}",
             hex::encode(&key.0),
             hex::encode(&value.0)
@@ -175,7 +177,7 @@ impl EvmRollupClient {
         .map_err(Self::convert_err)?;
 
         // #[cfg(feature = "logging")]
-        // pink::warn!("RawTx: {raw_tx:?}");
+        // warn!("RawTx: {raw_tx:?}");
 
         if let Some(head_idx) = raw_tx.queue_head {
             self.actions

--- a/phat/crates/rollup/src/clients/substrate.rs
+++ b/phat/crates/rollup/src/clients/substrate.rs
@@ -12,6 +12,7 @@ use pink::ResultExt;
 use pink_extension as pink;
 use pink_extension::AccountId;
 use primitive_types::H256;
+use logging::warn;
 
 const METHOD_CLAIM_NAME: u8 = 0u8;
 const METHOD_ROLLUP: u8 = 1u8;
@@ -47,7 +48,7 @@ impl<'a> KvSnapshot for SubstrateSnapshot<'a> {
             .or(Err(kv_session::Error::FailedToGetStorage))?;
 
         #[cfg(feature = "logging")]
-        pink::warn!(
+        warn!(
             "Storage[{}][{}] = {:?}",
             hex::encode(key1),
             hex::encode(key2),
@@ -147,7 +148,7 @@ impl<'a> SubstrateRollupClient<'a> {
         .map_err(Self::convert_err)?;
 
         // #[cfg(feature = "logging")]
-        // pink::warn!("RawTx: {raw_tx:?}");
+        // warn!("RawTx: {raw_tx:?}");
 
         if raw_tx.updates.is_empty() && self.actions.is_empty() {
             return Ok(None);
@@ -203,15 +204,15 @@ impl<'a> SubmittableRollupTx<'a> {
 
         #[cfg(feature = "logging")]
         {
-            pink::warn!("ContractId = {}", hex::encode(self.contract_id),);
-            pink::warn!("SignedTx = {}", hex::encode(&signed_tx),);
+            warn!("ContractId = {}", hex::encode(self.contract_id),);
+            warn!("SignedTx = {}", hex::encode(&signed_tx),);
         }
 
         let tx_hash = subrpc::send_transaction(self.rpc, &signed_tx)
             .or(Err(Error::FailedToSendTransaction))?;
 
         #[cfg(feature = "logging")]
-        pink::warn!("Sent = {}", hex::encode(&tx_hash),);
+        warn!("Sent = {}", hex::encode(&tx_hash),);
         Ok(tx_hash)
     }
 }
@@ -252,6 +253,6 @@ pub fn claim_name(
         subrpc::send_transaction(rpc, &signed_tx).or(Err(Error::FailedToSendTransaction))?;
 
     #[cfg(feature = "logging")]
-    pink::warn!("Sent = {}", hex::encode(&tx_hash),);
+    warn!("Sent = {}", hex::encode(&tx_hash),);
     Ok(tx_hash)
 }


### PR DESCRIPTION
## Summary
This PR implement simple logging span for bricks.
It is acheived by:
 - A crate `logging` which provides drop-in replacement of `pink::{info,debug...}` and a contract `trait TagStack`. 
 - A driver contract called `TagBag`.
## How it looks like
At the entry of the profile `fn poll`, we push a logging span there:
```rust
        /// Called by a scheduler periodically with Query
        #[ink(message)]
        pub fn poll(&mut self, workflow_id: WorkflowId, poll_id: String) -> Result<bool> {
            let _span = logging::enter_span(&format!("poll_id={poll_id}"));

            let profile = hex_fmt::HexFmt(self.env().account_id());
            info!("polling profile 0x{profile}:{workflow_id}");
```
Then all later logs using `logging::{info, debug...}` would be prefixed with the tag `poll_id={poll_id}`, as shown below:
```
2023-08-31T07:37:52.813426Z  INFO prpc{id=1554}:pink{blk=456}: pink: [5H8RS6UUr11ww6CLiCHSosnaPsSSy4CYwyfdXDeetxxzZAj7] [poll_id=YapaFFm_0]: polling profile 0xe002dca18f3d1186ac64f0cc451f5c44fee11bc78f9a602237c3d32bddf38616:0    
2023-08-31T07:37:52.819957Z  INFO prpc{id=1554}:pink{blk=456}: pink: [5CbBZP6BBthUbDMhhxLL71hEA9122CmEamAkbGuY4igwPa1z] [poll_id=YapaFFm_0]: lego_rs: actions=[{"cmd":"call","config":{"callee":"0x32693d5743839ed61b941a902a1d80aa6544caef58fb289fe4195104513cef26","selector":710659445}},{"cmd":"log"}]  
```